### PR TITLE
Bug in the watcher?

### DIFF
--- a/src/FireFS/Watcher/FileSystemWatcher.php
+++ b/src/FireFS/Watcher/FileSystemWatcher.php
@@ -318,12 +318,17 @@ class FileSystemWatcher
      */
     public function process()
     {
-        $oldWD = $this->_fs->workingDir();
-        $this->_fs->setWorkingDir($this->_fs->dirname($this->_path));
+        if (!$this->_started) {
+            $oldWD = $this->_fs->workingDir();
+            $this->_fs->setWorkingDir($this->_fs->dirname($this->_path));
+        }
         clearstatcache(true);
         $this->_detectChanges();
         $this->_cacheLastModTimes();
-        $this->_fs->setWorkingDir($oldWD);
+
+        if (!$this->_started) {
+            $this->_fs->setWorkingDir($oldWD);
+        }
     }
 
     /**


### PR DESCRIPTION
Hello,

I think there is a bug in the watcher.

I get the error
`Cannot read the file "/var/www/html/resources/lang": permission denied (The web server user cannot read files, chmod needed)` but the message is wrong because actually he reads method `$this->toInternalPath($path)` and the output is then `/var/www/html/resources/resources/lang` (double resources path)

This is my watcher:

````
$watcher = app('watcher');
$watcher->setListener(new Listener())
    ->setRecursive(true)
    ->setPath('./resources/lang')
    ->setWatchInterval(250)
    ->build();
$watcher->start();
````

Part of the file structure to watch
```
./resources/lang/en/file_1.php
./resources/lang/en/file_2.php
./resources/lang/nl/file_1.php
./resources/lang/nl/file_2.php
```

I created a fix but not 100% sure if this is oke / if I break something else and there are no automatic tests ... but this works for me.
I found the code is calling the method `setWorkingDir` twice and then the working directory is pointing to the wrong path.